### PR TITLE
Bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ packages/
 TestResults/
 _ReSharper.*
 *.xml
+*.ncrunchproject
+/_NCrunch_Its.Validation/StoredText

--- a/Validation.UnitTests/Its.Validation.UnitTests.csproj
+++ b/Validation.UnitTests/Its.Validation.UnitTests.csproj
@@ -69,6 +69,14 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.6.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.6.1\lib\net45\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.6.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.6.1\lib\net45\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
@@ -85,6 +93,7 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyVersion.cs">

--- a/Validation.UnitTests/ValidationPlanTests.cs
+++ b/Validation.UnitTests/ValidationPlanTests.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
 using Its.Validation.Configuration;
 using Its.Validation.UnitTests.TestClasses;
 using Moq;
@@ -521,7 +523,19 @@ namespace Its.Validation.UnitTests
                         Is.EqualTo(10));
         }
 
-        [NUnit.Framework.Ignore("Scenario not finished")]
+        [Test]
+        public void Null_rules_cannot_be_added_to_a_ValidationPlans()
+        {
+            var plan = new ValidationPlan<string>();
+
+            IValidationRule<string> nullRule = null;
+
+            Action addNullRule = () => plan.Add(nullRule);
+
+            addNullRule.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Ignore("Scenario not finished")]
         [Test]
         public void ValidationPlan_halts_on_first_failure_when_strategy_is_HaltOnFirstFailure()
         {

--- a/Validation.UnitTests/packages.config
+++ b/Validation.UnitTests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="4.6.1" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net40" />
   <package id="NUnit" version="2.6.1" targetFramework="net40" />
 </packages>

--- a/Validation/FailureMessageTemplate.cs
+++ b/Validation/FailureMessageTemplate.cs
@@ -35,10 +35,5 @@ namespace Its.Validation
             }
             return MessageGenerator.Detokenize(template, failedEvaluation.Parameters);
         }
-
-        public override string ToString()
-        {
-            return GetMessage(null);
-        }
     }
 }

--- a/Validation/FailureMessageTemplate{T}.cs
+++ b/Validation/FailureMessageTemplate{T}.cs
@@ -29,10 +29,5 @@ namespace Its.Validation
 
             return MessageGenerator.Detokenize(template, failedEvaluation.Parameters);
         }
-
-        public override string ToString()
-        {
-            return GetMessage(null);
-        }
     }
 }

--- a/Validation/SuccessMessageTemplate.cs
+++ b/Validation/SuccessMessageTemplate.cs
@@ -35,10 +35,5 @@ namespace Its.Validation
             }
             return MessageGenerator.Detokenize(template, successfulEvaluation.Parameters);
         }
-
-        public override string ToString()
-        {
-            return GetMessage(null);
-        }
     }
 }

--- a/Validation/SuccessMessageTemplate{T}.cs
+++ b/Validation/SuccessMessageTemplate{T}.cs
@@ -27,10 +27,5 @@ namespace Its.Validation
                                                             .ElseDefault());
             return MessageGenerator.Detokenize(template, successfulEvaluation.Parameters);
         }
-
-        public override string ToString()
-        {
-            return GetMessage(null);
-        }
     }
 }

--- a/Validation/ValidationPlan{T}.cs
+++ b/Validation/ValidationPlan{T}.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using Its.Validation.Configuration;
@@ -92,6 +91,10 @@ namespace Its.Validation
         public ValidationPlan<TTarget> AddRule(
             IValidationRule<TTarget> rule)
         {
+            if (rule == null)
+            {
+                throw new ArgumentNullException(nameof(rule));
+            }
             rules.Add(rule);
             return this;
         }

--- a/Validation/ValidationRule{T}.cs
+++ b/Validation/ValidationRule{T}.cs
@@ -229,11 +229,22 @@ namespace Its.Validation
         /// <returns> A <see cref="System.String" /> that represents this instance. </returns>
         public override string ToString()
         {
-            var failureMessage = Result<FailureMessageTemplate>();
-            if (failureMessage != null)
+            var currentRuleEvaluation = MessageContext.GetCurrentRuleEvaluation();
+
+            var successMessage = Result<SuccessMessageTemplate>();
+            if (successMessage != null && 
+                currentRuleEvaluation is SuccessfulEvaluation)
             {
-                return failureMessage.GetMessage(null);
+                return successMessage.GetMessage(currentRuleEvaluation);
             }
+
+            var failureMessage = Result<FailureMessageTemplate>();
+            if (failureMessage != null && 
+                currentRuleEvaluation is FailedEvaluation)
+            {
+                return failureMessage.GetMessage(currentRuleEvaluation);
+            }
+
             var value = Result<ErrorCode<string>>();
             var code = value != null ? value.Value : "";
             return code;


### PR DESCRIPTION
This fixes issue #1 and another bug where `DebugMessageGenerator` can throw `NullReferenceException` because it was evaluating both success and failure message templates.
